### PR TITLE
Update encode64 to strict_encode64 in RequestValidator#build_signatur…

### DIFF
--- a/lib/twilio-ruby/security/request_validator.rb
+++ b/lib/twilio-ruby/security/request_validator.rb
@@ -58,7 +58,7 @@ module Twilio
       def build_signature_for(url, params)
         data = url + params.sort.join
         digest = OpenSSL::Digest.new('sha1')
-        Base64.encode64(OpenSSL::HMAC.digest(digest, @auth_token, data)).strip
+        Base64.strict_encode64(OpenSSL::HMAC.digest(digest, @auth_token, data))
       end
 
       private


### PR DESCRIPTION
…e_for

Base64#strict_encode64 takes care of removing line feeds so no character stripping is required at the end

Please ensure the following steps have been run before submitting this pull request:

- [ ] Run `make test` and ensure it passes locally
- [ ] Run `make lint` to appease Rubocop
